### PR TITLE
Add `filter` arg to `aws_billing()` for Filter parameter in Cost Explorer Get Cost and Usage

### DIFF
--- a/R/billing.R
+++ b/R/billing.R
@@ -27,13 +27,14 @@
 #' for help
 #' @section Filtering:
 #' You can optionally pass a list to the `filter` argument to filter
-#' AWS costs by different dimensions (see possible dimensions: https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetDimensionValues.html)
-#' 
+#' AWS costs by different dimensions (see possible dimensions:
+#' <https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetDimensionValues.html>) #nolint
+#'
 #' This is supplied as a list of Dimensions, with key-value pairs for each
-#' Dimension. For example, to only get "Usage" costs as opposed to credits, 
-#' tax refunds etc., use the `RECORD_TYPE` dimension Key and set the Value to 
-#' "Usage" (see examples) 
-#' 
+#' Dimension. For example, to only get "Usage" costs as opposed to credits,
+#' tax refunds etc., use the `RECORD_TYPE` dimension Key and set the Value to
+#' "Usage" (see examples)
+#'
 #' @return tibble with columns:
 #' - id: "blended", "unblended"
 #' - date: date, in format `yyyy-MM-dd`
@@ -65,19 +66,24 @@
 #'   group_by(service) %>%
 #'   summarise(sum_cost = sum(cost)) %>%
 #'   filter(service == "Amazon Relational Database Service")
-#' 
+#'
 #' # Filter to return only "Usage" costs:
-#' 
+#'
 #' aws_billing(
-#'   date_start = start_date, 
+#'   date_start = start_date,
 #'   filter = list(
 #'     Dimensions = list(
 #'       Key = "RECORD_TYPE",
 #'       Values = "Usage"
-#'     ))
+#'     )
 #'   )
-#' 
-aws_billing <- function(date_start, date_end = as.character(Sys.Date()), filter = NULL) {
+#' )
+#'
+aws_billing <- function(
+  date_start,
+  date_end = as.character(Sys.Date()),
+  filter = NULL
+) {
   bind_rows(
     unblended = rename(
       billing_unblended(date_start, date_end, filter = filter),

--- a/R/billing.R
+++ b/R/billing.R
@@ -25,15 +25,19 @@
 #' beyond 14 months". See
 #' <https://docs.aws.amazon.com/cost-management/latest/userguide/ce-advanced-cost-analysis.html> #nolint
 #' for help
+#'
 #' @section Filtering:
-#' You can optionally pass a list to the `filter` argument to filter
-#' AWS costs by different dimensions (see possible dimensions:
+#' You can optionally pass a list to the `filter` argument to filter AWS costs
+#' by different dimensions, tags, or cost categories. This filter expression is
+#' passed on to
+#' [paws](https://www.paws-r-sdk.com/docs/costexplorer_get_cost_and_usage/). See
+#' possible dimensions:
 #' <https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetDimensionValues.html>) #nolint
 #'
-#' This is supplied as a list of Dimensions, with key-value pairs for each
-#' Dimension. For example, to only get "Usage" costs as opposed to credits,
-#' tax refunds etc., use the `RECORD_TYPE` dimension Key and set the Value to
-#' "Usage" (see examples)
+#' This is supplied as a list, with key-value pairs for each criteria.
+#' Different filter criteria can be combined in different ways using `AND`,
+#' `OR`, and `NOT`. See Examples below and more on Filter expressions at
+#' <https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_Expression.html>. #nolint
 #'
 #' @return tibble with columns:
 #' - id: "blended", "unblended"
@@ -67,8 +71,7 @@
 #'   summarise(sum_cost = sum(cost)) %>%
 #'   filter(service == "Amazon Relational Database Service")
 #'
-#' # Filter to return only "Usage" costs:
-#'
+#' # Simple filter to return only "Usage" costs:
 #' aws_billing(
 #'   date_start = start_date,
 #'   filter = list(
@@ -79,6 +82,61 @@
 #'   )
 #' )
 #'
+#' # Filter to return "Usage" costs for only m4.xlarge instances:
+#' aws_billing(
+#'   date_start = start_date,
+#'   filter = list(
+#'     And = list(
+#'       list(
+#'         Dimensions = list(
+#'           Key = "RECORD_TYPE",
+#'           Values = list("Usage")
+#'         )
+#'       ),
+#'       list(
+#'         Dimensions = list(
+#'           Key = "INSTANCE_TYPE",
+#'           Values = list("m4.xlarge")
+#'         )
+#'       )
+#'     )
+#'   )
+#' )
+#'
+#' # Complex filter example, translated from the AWS Cost Explorer docs:
+#' # <https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_Expression.html> #nolint
+#' # Filter for operations within us-west-1 or us-west-2 regions OR have a
+#' # specific Tag value, AND are NOT DataTransfer usage types:
+#' aws_billing(
+#'   date_start = start_date,
+#'   filter = list(
+#'     And = list(
+#'       list(
+#'         Or = list(
+#'           list(
+#'             Dimensions = list(
+#'               Key = "REGION",
+#'               Values = list("us-east-1", "us-west-1")
+#'             )
+#'           ),
+#'           list(
+#'             Tags = list(
+#'               Key = "TagName",
+#'               Values = list("Value1")
+#'             )
+#'           )
+#'         )
+#'       ),
+#'       list(
+#'         Not = list(
+#'           Dimensions = list(
+#'             Key = "USAGE_TYPE",
+#'             Values = list("DataTransfer")
+#'           )
+#'         )
+#'       )
+#'     ))
+#' )
 aws_billing <- function(
   date_start,
   date_end = as.character(Sys.Date()),

--- a/man/aws_billing.Rd
+++ b/man/aws_billing.Rd
@@ -51,14 +51,17 @@ for help
 
 \section{Filtering}{
 
-You can optionally pass a list to the \code{filter} argument to filter
-AWS costs by different dimensions (see possible dimensions:
+You can optionally pass a list to the \code{filter} argument to filter AWS costs
+by different dimensions, tags, or cost categories. This filter expression is
+passed on to
+\href{https://www.paws-r-sdk.com/docs/costexplorer_get_cost_and_usage/}{paws}. See
+possible dimensions:
 \url{https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetDimensionValues.html}) #nolint
 
-This is supplied as a list of Dimensions, with key-value pairs for each
-Dimension. For example, to only get "Usage" costs as opposed to credits,
-tax refunds etc., use the \code{RECORD_TYPE} dimension Key and set the Value to
-"Usage" (see examples)
+This is supplied as a list, with key-value pairs for each criteria.
+Different filter criteria can be combined in different ways using \code{AND},
+\code{OR}, and \code{NOT}. See Examples below and more on Filter expressions at
+\url{https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_Expression.html}. #nolint
 }
 
 \examples{
@@ -86,8 +89,7 @@ z \%>\%
   summarise(sum_cost = sum(cost)) \%>\%
   filter(service == "Amazon Relational Database Service")
 
-# Filter to return only "Usage" costs:
-
+# Simple filter to return only "Usage" costs:
 aws_billing(
   date_start = start_date,
   filter = list(
@@ -96,6 +98,62 @@ aws_billing(
       Values = "Usage"
     )
   )
+)
+
+# Filter to return "Usage" costs for only m4.xlarge instances:
+aws_billing(
+  date_start = start_date,
+  filter = list(
+    And = list(
+      list(
+        Dimensions = list(
+          Key = "RECORD_TYPE",
+          Values = list("Usage")
+        )
+      ),
+      list(
+        Dimensions = list(
+          Key = "INSTANCE_TYPE",
+          Values = list("m4.xlarge")
+        )
+      )
+    )
+  )
+)
+
+# Complex filter example, translated from the AWS Cost Explorer docs:
+# <https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_Expression.html> #nolint
+# Filter for operations within us-west-1 or us-west-2 regions OR have a
+# specific Tag value, AND are NOT DataTransfer usage types:
+aws_billing(
+  date_start = start_date,
+  filter = list(
+    And = list(
+      list(
+        Or = list(
+          list(
+            Dimensions = list(
+              Key = "REGION",
+              Values = list("us-east-1", "us-west-1")
+            )
+          ),
+          list(
+            Tags = list(
+              Key = "TagName",
+              Values = list("Value1")
+            )
+          )
+        )
+      ),
+      list(
+        Not = list(
+          Dimensions = list(
+            Key = "USAGE_TYPE",
+            Values = list("DataTransfer")
+          )
+        )
+      )
+    ))
 )
 \dontshow{\}) # examplesIf}
 }

--- a/man/aws_billing.Rd
+++ b/man/aws_billing.Rd
@@ -52,7 +52,8 @@ for help
 \section{Filtering}{
 
 You can optionally pass a list to the \code{filter} argument to filter
-AWS costs by different dimensions (see possible dimensions: https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetDimensionValues.html)
+AWS costs by different dimensions (see possible dimensions:
+\url{https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetDimensionValues.html}) #nolint
 
 This is supplied as a list of Dimensions, with key-value pairs for each
 Dimension. For example, to only get "Usage" costs as opposed to credits,
@@ -88,13 +89,14 @@ z \%>\%
 # Filter to return only "Usage" costs:
 
 aws_billing(
-  date_start = start_date, 
+  date_start = start_date,
   filter = list(
     Dimensions = list(
       Key = "RECORD_TYPE",
       Values = "Usage"
-    ))
+    )
   )
+)
 \dontshow{\}) # examplesIf}
 }
 \references{

--- a/man/aws_billing.Rd
+++ b/man/aws_billing.Rd
@@ -4,11 +4,13 @@
 \alias{aws_billing}
 \title{Fetch billing data - with some internal munging for ease of use}
 \usage{
-aws_billing(date_start, date_end = as.character(Sys.Date()))
+aws_billing(date_start, date_end = as.character(Sys.Date()), filter = NULL)
 }
 \arguments{
 \item{date_start, date_end}{Start and end date to get billing data for.
 Date format expected: \code{yyyy-MM-dd}. required}
+
+\item{filter}{(list) filters costs by different dimensions. optional.}
 }
 \value{
 tibble with columns:
@@ -47,6 +49,17 @@ beyond 14 months". See
 for help
 }
 
+\section{Filtering}{
+
+You can optionally pass a list to the \code{filter} argument to filter
+AWS costs by different dimensions (see possible dimensions: https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetDimensionValues.html)
+
+This is supplied as a list of Dimensions, with key-value pairs for each
+Dimension. For example, to only get "Usage" costs as opposed to credits,
+tax refunds etc., use the \code{RECORD_TYPE} dimension Key and set the Value to
+"Usage" (see examples)
+}
+
 \examples{
 \dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(lubridate)
@@ -71,6 +84,17 @@ z \%>\%
   group_by(service) \%>\%
   summarise(sum_cost = sum(cost)) \%>\%
   filter(service == "Amazon Relational Database Service")
+
+# Filter to return only "Usage" costs:
+
+aws_billing(
+  date_start = start_date, 
+  filter = list(
+    Dimensions = list(
+      Key = "RECORD_TYPE",
+      Values = "Usage"
+    ))
+  )
 \dontshow{\}) # examplesIf}
 }
 \references{


### PR DESCRIPTION
<!-- 
Maintainers: This issue template comes from https://github.com/getwilds/.github
You're encouraged to add your own that's optimized for your repo 

Is this a PR to main branch (or whatever the default branch is called)?
- Code can only be added to main via PR
- A project lead has to approve a PR to main
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Sorry, this has been a while in coming! This allows filtering of Get Cost and Usage queries. Adds `filter` argument to `aws_billing()`, passed through to `aws_billing_raw()`, making use of the `Filter` argument in [`ce$get_cost_and_usage()` in paws](https://www.paws-r-sdk.com/docs/costexplorer_get_cost_and_usage/#arguments)

## Related Issue
Closes #72 

## Example
```r
aws_billing(
  date_start = as.character(Sys.Date() - 30),
  filter = list(
    Dimensions = list(
      Key = "RECORD_TYPE",
      Values = "Usage"
    )
  )
)
```

## Testing
There aren't currently any tests for billing. Looking at LocalStack, [it looks like you need the pro version for the Cost Explorer API](https://docs.localstack.cloud/references/coverage/coverage_ce/). Do you have thoughts on how to enable testing for `aws_billing()`?
