### PR TITLE
Add namespace prefix to lazily-loaded data object

### DIFF
--- a/R/billing.R
+++ b/R/billing.R
@@ -196,7 +196,7 @@ billing_factory <- function(type) {
         )
       }) %>%
       list_rbind() %>%
-      left_join(service_map, by = c("Service" = "service")) %>%
+      left_join(sixtyfour::service_map, by = c("Service" = "service")) %>%
       mutate(acronym = coalesce(acronym, Service))
   }
 }

--- a/R/globals.R
+++ b/R/globals.R
@@ -3,7 +3,6 @@
 utils::globalVariables(c(
   "UnblendedCost", # <aws_billing>
   "BlendedCost", # <aws_billing>
-  "service_map", # <billing_factory>
   "acronym", # <billing_factory>
   "Service", # <billing_factory>
   "Size", # <aws_bucket_list_objects>


### PR DESCRIPTION
## Description
Add namespace prefix to `service_map` data object as it's not in the package namespace.

## Related Issue
Fixes #83 
