### PR TITLE
Fix errant library line and stubborn examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ eg:
 	${RSCRIPT} -e 'pkgload::load_all(); pkgload::run_example(${MAN_TARGET})'
 
 check: build
-	_R_CHECK_CRAN_INCOMING_=FALSE R CMD CHECK --as-cran --no-manual `ls -1tr ${PACKAGE}*gz | tail -n1`
+	_R_CHECK_SYSTEM_CLOCK_=0 _R_CHECK_CRAN_INCOMING_=FALSE R CMD CHECK --as-cran --no-manual `ls -1tr ${PACKAGE}*gz | tail -n1`
 	@rm -f `ls -1tr ${PACKAGE}*gz | tail -n1`
 	@rm -rf ${PACKAGE}.Rcheck
 

--- a/R/files.R
+++ b/R/files.R
@@ -61,6 +61,7 @@ aws_file_attr <- function(remote_path) {
 #' @examplesIf aws_has_creds()
 #' bucket1 <- random_string("bucket")
 #' aws_bucket_create(bucket1)
+#' cat(bucket1)
 #' demo_rds_file <- file.path(system.file(), "Meta/demo.rds")
 #' aws_file_upload(
 #'   demo_rds_file,
@@ -72,15 +73,18 @@ aws_file_attr <- function(remote_path) {
 #' if (!aws_bucket_exists(bucket2)) {
 #'   aws_bucket_create(bucket2)
 #' }
+#' cat(bucket2)
 #' links_file <- file.path(system.file(), "Meta/links.rds")
 #' aws_file_upload(
 #'   c(demo_rds_file, links_file),
-#'   s3_path(bucket2, c(basename(demo_rds_file), basename(links_file)))
+#'   s3_path(bucket2, c(basename(demo_rds_file), basename(links_file))),
+#'   overwrite = TRUE
 #' )
 #'
 #' # set expiration, expire 1 minute from now
 #' aws_file_upload(demo_rds_file, s3_path(bucket2, "ddd.rds"),
-#'   Expires = Sys.time() + 60
+#'   Expires = Sys.time() + 60,
+#'   overwrite = TRUE
 #' )
 #'
 #' # bucket doesn't exist
@@ -97,23 +101,28 @@ aws_file_attr <- function(remote_path) {
 #' # Path's without file extensions behave a little weird
 #' ## With extension
 #' bucket3 <- random_string("bucket")
-#' aws_bucket_create(bucket3)
+#' if (!aws_bucket_exists(bucket3)) {
+#'   aws_bucket_create(bucket3)
+#' }
 #' ## Both the next two lines do the same exact thing: make a file in the
 #' ## same path in a bucket
 #' pkg_rds_file <- file.path(system.file(), "Meta/package.rds")
-#' aws_file_upload(pkg_rds_file, s3_path(bucket3, "package2.rds"))
-#' aws_file_upload(pkg_rds_file, s3_path(bucket3))
+#' aws_file_upload(pkg_rds_file, s3_path(bucket3, "package2.rds"),
+#'  overwrite = TRUE)
+#' aws_file_upload(pkg_rds_file, s3_path(bucket3),
+#'  overwrite = TRUE)
 #'
 #' ## Without extension
 #' ## However, it's different for a file without an extension
 #' ## This makes a file in the bucket at path DESCRIPTION
 #' rd_file <- file.path(system.file(), "Meta/Rd.rds")
 #' desc_file <- system.file("DESCRIPTION", package = "sixtyfour")
-#' aws_file_upload(desc_file, s3_path(bucket3))
+#' aws_file_upload(desc_file, s3_path(bucket3), overwrite = TRUE)
 #'
 #' ## Whereas this creates a directory called DESCRIPTION with
 #' ## a file DESCRIPTION within it
-#' aws_file_upload(desc_file, s3_path(bucket3, "DESCRIPTION"))
+#' aws_file_upload(desc_file, s3_path(bucket3, "DESCRIPTION"),
+#'   overwrite = TRUE)
 #'
 #' # Cleanup
 #' six_bucket_delete(bucket1, force = TRUE)

--- a/R/files.R
+++ b/R/files.R
@@ -11,6 +11,41 @@ equal_lengths <- function(x, y) {
   }
 }
 
+#' File attributes
+#'
+#' @export
+#' @inheritParams aws_file_download
+#' @return a tibble with many columns, with number of rows matching length
+#' of `remote_path`
+#' @note uses [s3fs::s3_file_info()] internally
+#' @family files
+#' @examplesIf aws_has_creds()
+#' library(glue)
+#' bucket <- random_string("bucket")
+#' if (!aws_bucket_exists(bucket)) {
+#'   aws_bucket_create(bucket)
+#' }
+#'
+#' # upload some files
+#' tfiles <- replicate(n = 3, tempfile())
+#' paths <- s3_path(bucket, glue("{basename(tfiles)}.txt"))
+#' for (file in tfiles) cat("Hello saturn!!!!!!\n", file = file)
+#' for (file in tfiles) print(readLines(file))
+#' aws_file_upload(path = tfiles, remote_path = paths)
+#'
+#' # files one by one
+#' aws_file_attr(paths[1])
+#' aws_file_attr(paths[2])
+#' aws_file_attr(paths[3])
+#' # or all together
+#' aws_file_attr(paths)
+#'
+#' # Cleanup
+#' six_bucket_delete(bucket, force = TRUE)
+aws_file_attr <- function(remote_path) {
+  con_s3fs()$file_info(remote_path) %>% as_tibble()
+}
+
 #' Upload a file
 #'
 #' @export
@@ -34,7 +69,9 @@ equal_lengths <- function(x, y) {
 #'
 #' ## many files at once
 #' bucket2 <- random_string("bucket")
-#' aws_bucket_create(bucket2)
+#' if (!aws_bucket_exists(bucket2)) {
+#'   aws_bucket_create(bucket2)
+#' }
 #' links_file <- file.path(system.file(), "Meta/links.rds")
 #' aws_file_upload(
 #'   c(demo_rds_file, links_file),
@@ -63,17 +100,20 @@ equal_lengths <- function(x, y) {
 #' aws_bucket_create(bucket3)
 #' ## Both the next two lines do the same exact thing: make a file in the
 #' ## same path in a bucket
-#' aws_file_upload("LICENSE.md", s3_path(bucket3, "LICENSE2.md"))
-#' aws_file_upload("LICENSE.md", s3_path(bucket3))
+#' pkg_rds_file <- file.path(system.file(), "Meta/package.rds")
+#' aws_file_upload(pkg_rds_file, s3_path(bucket3, "package2.rds"))
+#' aws_file_upload(pkg_rds_file, s3_path(bucket3))
 #'
 #' ## Without extension
 #' ## However, it's different for a file without an extension
 #' ## This makes a file in the bucket at path DESCRIPTION
-#' aws_file_upload("DESCRIPTION", s3_path(bucket3))
+#' rd_file <- file.path(system.file(), "Meta/Rd.rds")
+#' desc_file <- system.file("DESCRIPTION", package = "sixtyfour")
+#' aws_file_upload(desc_file, s3_path(bucket3))
 #'
 #' ## Whereas this creates a directory called DESCRIPTION with
 #' ## a file DESCRIPTION within it
-#' aws_file_upload("DESCRIPTION", s3_path(bucket3, "DESCRIPTION"))
+#' aws_file_upload(desc_file, s3_path(bucket3, "DESCRIPTION"))
 #'
 #' # Cleanup
 #' six_bucket_delete(bucket1, force = TRUE)
@@ -266,39 +306,6 @@ aws_file_delete_one <- function(one_path, ...) {
     glue("{key}{ifelse(trailing_slash, '/', '')}")
   )
   invisible()
-}
-
-#' File attributes
-#'
-#' @export
-#' @inheritParams aws_file_download
-#' @return a tibble with many columns, with number of rows matching length
-#' of `remote_path`
-#' @note uses [s3fs::s3_file_info()] internally
-#' @family files
-#' @examplesIf aws_has_creds()
-#' library(glue)
-#' bucket <- random_string("bucket")
-#' aws_bucket_create(bucket)
-#'
-#' # upload some files
-#' tfiles <- replicate(n = 3, tempfile())
-#' paths <- s3_path(bucket, glue("{basename(tfiles)}.txt"))
-#' for (file in tfiles) cat("Hello saturn!!!!!!\n", file = file)
-#' for (file in tfiles) print(readLines(file))
-#' aws_file_upload(path = tfiles, remote_path = paths)
-#'
-#' # files one by one
-#' aws_file_attr(paths[1])
-#' aws_file_attr(paths[2])
-#' aws_file_attr(paths[3])
-#' # or all together
-#' aws_file_attr(paths)
-#'
-#' # Cleanup
-#' six_bucket_delete(bucket, force = TRUE)
-aws_file_attr <- function(remote_path) {
-  con_s3fs()$file_info(remote_path) %>% as_tibble()
 }
 
 #' Check if a file exists

--- a/R/files.R
+++ b/R/files.R
@@ -276,8 +276,8 @@ aws_file_delete_one <- function(one_path, ...) {
 #' of `remote_path`
 #' @note uses [s3fs::s3_file_info()] internally
 #' @family files
-#' library(glue)
 #' @examplesIf aws_has_creds()
+#' library(glue)
 #' bucket <- random_string("bucket")
 #' aws_bucket_create(bucket)
 #'

--- a/man/aws_file_attr.Rd
+++ b/man/aws_file_attr.Rd
@@ -23,7 +23,9 @@ uses \code{\link[s3fs:info]{s3fs::s3_file_info()}} internally
 \dontshow{if (aws_has_creds()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(glue)
 bucket <- random_string("bucket")
-aws_bucket_create(bucket)
+if (!aws_bucket_exists(bucket)) {
+  aws_bucket_create(bucket)
+}
 
 # upload some files
 tfiles <- replicate(n = 3, tempfile())

--- a/man/aws_file_attr.Rd
+++ b/man/aws_file_attr.Rd
@@ -21,6 +21,7 @@ uses \code{\link[s3fs:info]{s3fs::s3_file_info()}} internally
 }
 \examples{
 \dontshow{if (aws_has_creds()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+library(glue)
 bucket <- random_string("bucket")
 aws_bucket_create(bucket)
 

--- a/man/aws_file_upload.Rd
+++ b/man/aws_file_upload.Rd
@@ -35,7 +35,9 @@ aws_file_upload(
 
 ## many files at once
 bucket2 <- random_string("bucket")
-aws_bucket_create(bucket2)
+if (!aws_bucket_exists(bucket2)) {
+  aws_bucket_create(bucket2)
+}
 links_file <- file.path(system.file(), "Meta/links.rds")
 aws_file_upload(
   c(demo_rds_file, links_file),
@@ -64,17 +66,20 @@ bucket3 <- random_string("bucket")
 aws_bucket_create(bucket3)
 ## Both the next two lines do the same exact thing: make a file in the
 ## same path in a bucket
-aws_file_upload("LICENSE.md", s3_path(bucket3, "LICENSE2.md"))
-aws_file_upload("LICENSE.md", s3_path(bucket3))
+pkg_rds_file <- file.path(system.file(), "Meta/package.rds")
+aws_file_upload(pkg_rds_file, s3_path(bucket3, "package2.rds"))
+aws_file_upload(pkg_rds_file, s3_path(bucket3))
 
 ## Without extension
 ## However, it's different for a file without an extension
 ## This makes a file in the bucket at path DESCRIPTION
-aws_file_upload("DESCRIPTION", s3_path(bucket3))
+rd_file <- file.path(system.file(), "Meta/Rd.rds")
+desc_file <- system.file("DESCRIPTION", package = "sixtyfour")
+aws_file_upload(desc_file, s3_path(bucket3))
 
 ## Whereas this creates a directory called DESCRIPTION with
 ## a file DESCRIPTION within it
-aws_file_upload("DESCRIPTION", s3_path(bucket3, "DESCRIPTION"))
+aws_file_upload(desc_file, s3_path(bucket3, "DESCRIPTION"))
 
 # Cleanup
 six_bucket_delete(bucket1, force = TRUE)

--- a/man/aws_file_upload.Rd
+++ b/man/aws_file_upload.Rd
@@ -27,6 +27,7 @@ to upload a folder of files see \code{\link[=aws_bucket_upload]{aws_bucket_uploa
 \dontshow{if (aws_has_creds()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 bucket1 <- random_string("bucket")
 aws_bucket_create(bucket1)
+cat(bucket1)
 demo_rds_file <- file.path(system.file(), "Meta/demo.rds")
 aws_file_upload(
   demo_rds_file,
@@ -38,15 +39,18 @@ bucket2 <- random_string("bucket")
 if (!aws_bucket_exists(bucket2)) {
   aws_bucket_create(bucket2)
 }
+cat(bucket2)
 links_file <- file.path(system.file(), "Meta/links.rds")
 aws_file_upload(
   c(demo_rds_file, links_file),
-  s3_path(bucket2, c(basename(demo_rds_file), basename(links_file)))
+  s3_path(bucket2, c(basename(demo_rds_file), basename(links_file))),
+  overwrite = TRUE
 )
 
 # set expiration, expire 1 minute from now
 aws_file_upload(demo_rds_file, s3_path(bucket2, "ddd.rds"),
-  Expires = Sys.time() + 60
+  Expires = Sys.time() + 60,
+  overwrite = TRUE
 )
 
 # bucket doesn't exist
@@ -63,23 +67,28 @@ try(
 # Path's without file extensions behave a little weird
 ## With extension
 bucket3 <- random_string("bucket")
-aws_bucket_create(bucket3)
+if (!aws_bucket_exists(bucket3)) {
+  aws_bucket_create(bucket3)
+}
 ## Both the next two lines do the same exact thing: make a file in the
 ## same path in a bucket
 pkg_rds_file <- file.path(system.file(), "Meta/package.rds")
-aws_file_upload(pkg_rds_file, s3_path(bucket3, "package2.rds"))
-aws_file_upload(pkg_rds_file, s3_path(bucket3))
+aws_file_upload(pkg_rds_file, s3_path(bucket3, "package2.rds"),
+ overwrite = TRUE)
+aws_file_upload(pkg_rds_file, s3_path(bucket3),
+ overwrite = TRUE)
 
 ## Without extension
 ## However, it's different for a file without an extension
 ## This makes a file in the bucket at path DESCRIPTION
 rd_file <- file.path(system.file(), "Meta/Rd.rds")
 desc_file <- system.file("DESCRIPTION", package = "sixtyfour")
-aws_file_upload(desc_file, s3_path(bucket3))
+aws_file_upload(desc_file, s3_path(bucket3), overwrite = TRUE)
 
 ## Whereas this creates a directory called DESCRIPTION with
 ## a file DESCRIPTION within it
-aws_file_upload(desc_file, s3_path(bucket3, "DESCRIPTION"))
+aws_file_upload(desc_file, s3_path(bucket3, "DESCRIPTION"),
+  overwrite = TRUE)
 
 # Cleanup
 six_bucket_delete(bucket1, force = TRUE)


### PR DESCRIPTION
- `library` call was in the wrong place
- had to change some file examples that were failing during r cmd check because somehow the randomly created bucket names were somehow leading to errors where the bucket was already created. best guess is somehow the examples for those fxns were being run twice? but that still doesn't make sense, not sure 🤷🏽 
- add `_R_CHECK_SYSTEM_CLOCK_=0` so that r cmd check doesn't hang on checking system clock, not necessary