### PR TITLE
Add vignette for working with s3 and iam together 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,13 @@ vign_auth:
 	${RSCRIPT} -e "Sys.setenv(NOT_CRAN='true'); knitr::knit('auth.Rmd.og', output = 'auth.Rmd')";\
 	cd ..
 
+vign_s3iam:
+	cd vignettes;\
+	${RSCRIPT} -e "Sys.setenv(NOT_CRAN='true')" \
+	-e "knitr::knit('s3iam.Rmd.og', output = 's3iam.Rmd')";\
+	sed "s/${AWS_ACCOUNT_ID}/*****/g" s3iam.Rmd > tmp && mv tmp s3iam.Rmd;\
+	cd ..
+
 test:
 	SIXTYFOUR_RUN_LOCAL_ONLY_TESTS=true ${RSCRIPT} -e "devtools::test()"
 

--- a/vignettes/s3iam.Rmd
+++ b/vignettes/s3iam.Rmd
@@ -51,8 +51,8 @@ The admin user:
 ``` r
 name_admin <- random_user()
 user_admin <- six_user_create(name_admin, copy_to_cb = FALSE)
-#> ℹ Added policy UserInfo to UpstartCoding
-#> ✔ Key pair created for UpstartCoding
+#> ℹ Added policy UserInfo to PromisingReinfor
+#> ✔ Key pair created for PromisingReinfor
 #> ℹ AccessKeyId: *****
 #> ℹ SecretAccessKey: *****
 aws_user_add_to_group(name_admin, "myadmin")
@@ -65,16 +65,16 @@ The non-admin users:
 users_non_admin <- map(1:3, \(x) {
   six_user_create(random_user(), copy_to_cb = FALSE)
 })
-#> ℹ Added policy UserInfo to FumingMatron
-#> ✔ Key pair created for FumingMatron
+#> ℹ Added policy UserInfo to SummaryColleague
+#> ✔ Key pair created for SummaryColleague
 #> ℹ AccessKeyId: *****
 #> ℹ SecretAccessKey: *****
-#> ℹ Added policy UserInfo to ForkedBounds
-#> ✔ Key pair created for ForkedBounds
+#> ℹ Added policy UserInfo to DeludedArrow
+#> ✔ Key pair created for DeludedArrow
 #> ℹ AccessKeyId: *****
 #> ℹ SecretAccessKey: *****
-#> ℹ Added policy UserInfo to MemorableLustre
-#> ✔ Key pair created for MemorableLustre
+#> ℹ Added policy UserInfo to SanctionedStilln
+#> ✔ Key pair created for SanctionedStilln
 #> ℹ AccessKeyId: *****
 #> ℹ SecretAccessKey: *****
 invisible(map(users_non_admin, \(x) {
@@ -89,8 +89,8 @@ And last, create a user that is not part of either of the above groups.
 ``` r
 name_user_wo <- random_user()
 user_wo_access <- six_user_create(name_user_wo, copy_to_cb = FALSE)
-#> ℹ Added policy UserInfo to PedestrianDoorst
-#> ✔ Key pair created for PedestrianDoorst
+#> ℹ Added policy UserInfo to UndisturbedMayor
+#> ✔ Key pair created for UndisturbedMayor
 #> ℹ AccessKeyId: *****
 #> ℹ SecretAccessKey: *****
 ```
@@ -104,7 +104,7 @@ Create a bucket, and put a file in it.
 bucket <- random_string("bucket")
 demo_rds_file <- file.path(system.file(), "Meta/demo.rds")
 six_bucket_upload(path = demo_rds_file, remote = bucket, force = TRUE)
-#> [1] "s3://bucketqozlabhg/demo.rds"
+#> [1] "s3://bucketuqsahenb/demo.rds"
 ```
 
 ## Check access
@@ -122,25 +122,40 @@ withr::with_envvar(
   ),
   aws_bucket_list_objects(bucket)
 )
-#> Error: AccessDenied (HTTP 403). User: arn:aws:iam::*****:user/PedestrianDoorst is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::bucketqozlabhg" because no identity-based policy allows the s3:ListBucket action
+#> Error: AccessDenied (HTTP 403). User: arn:aws:iam::*****:user/UndisturbedMayor is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::bucketuqsahenb" because no identity-based policy allows the s3:ListBucket action
 ```
 
-User PedestrianDoorst does not have access (read or write), as intended.
+User UndisturbedMayor does not have access (read or write), as intended.
 
-Then check access for a user that should have read access:
+Then check access for a user that should have read access and NOT write access:
 
 
 ``` r
+# Read
 withr::with_envvar(
   c("AWS_REGION" = users_non_admin[[1]]$AwsRegion,
     "AWS_ACCESS_KEY_ID" = users_non_admin[[1]]$AccessKeyId,
     "AWS_SECRET_ACCESS_KEY" = users_non_admin[[1]]$SecretAccessKey
   ),
   {
-    # read
     aws_bucket_list_objects(bucket)
+  }
+)
+#> # A tibble: 1 × 8
+#>   bucket         key    uri    size type  etag  lastmodified        storageclass
+#>   <glue>         <chr>  <glu> <fs:> <chr> <chr> <dttm>              <chr>       
+#> 1 bucketuqsahenb demo.… s3:/…   257 file  "\"2… 2025-02-28 17:22:36 STANDARD
+```
 
-    # write
+
+``` r
+# Write
+withr::with_envvar(
+  c("AWS_REGION" = users_non_admin[[1]]$AwsRegion,
+    "AWS_ACCESS_KEY_ID" = users_non_admin[[1]]$AccessKeyId,
+    "AWS_SECRET_ACCESS_KEY" = users_non_admin[[1]]$SecretAccessKey
+  ),
+  {
     links_rds_file <- file.path(system.file(), "Meta/links.rds")
     six_bucket_upload(path = links_rds_file, remote = bucket, force = TRUE)
   }
@@ -148,32 +163,46 @@ withr::with_envvar(
 #> Error in `map()`:
 #> ℹ In index: 1.
 #> Caused by error:
-#> ! AccessDenied (HTTP 403). User: arn:aws:iam::*****:user/FumingMatron is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::bucketqozlabhg/links.rds" because no identity-based policy allows the s3:PutObject action
+#> ! AccessDenied (HTTP 403). User: arn:aws:iam::*****:user/SummaryColleague is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::bucketuqsahenb/links.rds" because no identity-based policy allows the s3:PutObject action
 ```
 
-User FumingMatron does have access for read and NOT for write, as intended.
+User SummaryColleague does have access for read and NOT for write, as intended.
 
 And make sure the admin has read and write access
 
 
 ``` r
+# Read
 withr::with_envvar(
   c("AWS_REGION" = user_admin$AwsRegion,
     "AWS_ACCESS_KEY_ID" = user_admin$AccessKeyId,
     "AWS_SECRET_ACCESS_KEY" = user_admin$SecretAccessKey
   ), {
-    # read
     aws_bucket_list_objects(bucket)
+  }
+)
+#> # A tibble: 1 × 8
+#>   bucket         key    uri    size type  etag  lastmodified        storageclass
+#>   <glue>         <chr>  <glu> <fs:> <chr> <chr> <dttm>              <chr>       
+#> 1 bucketuqsahenb demo.… s3:/…   257 file  "\"2… 2025-02-28 17:22:36 STANDARD
+```
 
-    # write
+
+``` r
+# Write
+withr::with_envvar(
+  c("AWS_REGION" = user_admin$AwsRegion,
+    "AWS_ACCESS_KEY_ID" = user_admin$AccessKeyId,
+    "AWS_SECRET_ACCESS_KEY" = user_admin$SecretAccessKey
+  ), {
     links_rds_file <- file.path(system.file(), "Meta/links.rds")
     six_bucket_upload(path = links_rds_file, remote = bucket, force = TRUE)
   }
 )
-#> [1] "s3://bucketqozlabhg/links.rds"
+#> [1] "s3://bucketuqsahenb/links.rds"
 ```
 
-User UpstartCoding does have access for read and write, as intended.
+User PromisingReinfor DOES have access for read and write, as intended.
 
 ## Cleanup
 

--- a/vignettes/s3iam.Rmd
+++ b/vignettes/s3iam.Rmd
@@ -1,0 +1,192 @@
+---
+title: "Managing buckets in a small group of users"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Managing buckets in a small group of users}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+
+
+A common use case is to manage a small group of users and their access to AWS resources. This can be done using the `sixtyfour` package, which provides a set of high-level functions to make your life easier.
+
+## Installation
+
+
+``` r
+library(sixtyfour)
+library(purrr)
+```
+
+## User groups
+
+First, create two user groups - `admin` and `users` - with the `six_admin_setup()` function.
+
+
+
+
+``` r
+six_admin_setup(users_group = "myusers", admin_group = "myadmin")
+#> ℹ whoami: *****
+#> ℹ
+#> ℹ myusers group created - add users to this group that do not require admin permissions
+#> ℹ Added policies to the myusers group: AmazonRDSReadOnlyAccess, AmazonRedshiftReadOnlyAccess, AmazonS3ReadOnlyAccess,
+#> AWSBillingReadOnlyAccess, and IAMReadOnlyAccess
+#> ℹ
+#> ℹ myadmin group created - add users to this group that require admin permissions
+#> ℹ Added policies to the myadmin group: AdministratorAccess, Billing, CostOptimizationHubAdminAccess, AWSBillingReadOnlyAccess, and
+#> AWSCostAndUsageReportAutomationPolicy
+#> ℹ
+#> ℹ Done!
+```
+
+## Users
+
+Next, create five users - one in the `admin` group, three in the `users` group, and one not in either group.
+
+The admin user:
+
+
+``` r
+name_admin <- random_user()
+user_admin <- six_user_create(name_admin, copy_to_cb = FALSE)
+#> ℹ Added policy UserInfo to UpstartCoding
+#> ✔ Key pair created for UpstartCoding
+#> ℹ AccessKeyId: *****
+#> ℹ SecretAccessKey: *****
+aws_user_add_to_group(name_admin, "myadmin")
+```
+
+The non-admin users:
+
+
+``` r
+users_non_admin <- map(1:3, \(x) {
+  six_user_create(random_user(), copy_to_cb = FALSE)
+})
+#> ℹ Added policy UserInfo to FumingMatron
+#> ✔ Key pair created for FumingMatron
+#> ℹ AccessKeyId: *****
+#> ℹ SecretAccessKey: *****
+#> ℹ Added policy UserInfo to ForkedBounds
+#> ✔ Key pair created for ForkedBounds
+#> ℹ AccessKeyId: *****
+#> ℹ SecretAccessKey: *****
+#> ℹ Added policy UserInfo to MemorableLustre
+#> ✔ Key pair created for MemorableLustre
+#> ℹ AccessKeyId: *****
+#> ℹ SecretAccessKey: *****
+invisible(map(users_non_admin, \(x) {
+  aws_user_add_to_group(x$UserName, "myusers")
+}))
+names_users <- map_chr(users_non_admin, \(x) x$UserName)
+```
+
+And last, create a user that is not part of either of the above groups.
+
+
+``` r
+name_user_wo <- random_user()
+user_wo_access <- six_user_create(name_user_wo, copy_to_cb = FALSE)
+#> ℹ Added policy UserInfo to PedestrianDoorst
+#> ✔ Key pair created for PedestrianDoorst
+#> ℹ AccessKeyId: *****
+#> ℹ SecretAccessKey: *****
+```
+
+## Buckets and files
+
+Create a bucket, and put a file in it.
+
+
+``` r
+bucket <- random_string("bucket")
+demo_rds_file <- file.path(system.file(), "Meta/demo.rds")
+six_bucket_upload(path = demo_rds_file, remote = bucket, force = TRUE)
+#> [1] "s3://bucketqozlabhg/demo.rds"
+```
+
+## Check access
+
+Then check access for the user that should not have access
+
+
+
+
+``` r
+withr::with_envvar(
+  c("AWS_REGION" = user_wo_access$AwsRegion,
+    "AWS_ACCESS_KEY_ID" = user_wo_access$AccessKeyId,
+    "AWS_SECRET_ACCESS_KEY" = user_wo_access$SecretAccessKey
+  ),
+  aws_bucket_list_objects(bucket)
+)
+#> Error: AccessDenied (HTTP 403). User: arn:aws:iam::*****:user/PedestrianDoorst is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::bucketqozlabhg" because no identity-based policy allows the s3:ListBucket action
+```
+
+User PedestrianDoorst does not have access (read or write), as intended.
+
+Then check access for a user that should have read access:
+
+
+``` r
+withr::with_envvar(
+  c("AWS_REGION" = users_non_admin[[1]]$AwsRegion,
+    "AWS_ACCESS_KEY_ID" = users_non_admin[[1]]$AccessKeyId,
+    "AWS_SECRET_ACCESS_KEY" = users_non_admin[[1]]$SecretAccessKey
+  ),
+  {
+    # read
+    aws_bucket_list_objects(bucket)
+
+    # write
+    links_rds_file <- file.path(system.file(), "Meta/links.rds")
+    six_bucket_upload(path = links_rds_file, remote = bucket, force = TRUE)
+  }
+)
+#> Error in `map()`:
+#> ℹ In index: 1.
+#> Caused by error:
+#> ! AccessDenied (HTTP 403). User: arn:aws:iam::*****:user/FumingMatron is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::bucketqozlabhg/links.rds" because no identity-based policy allows the s3:PutObject action
+```
+
+User FumingMatron does have access for read and NOT for write, as intended.
+
+And make sure the admin has read and write access
+
+
+``` r
+withr::with_envvar(
+  c("AWS_REGION" = user_admin$AwsRegion,
+    "AWS_ACCESS_KEY_ID" = user_admin$AccessKeyId,
+    "AWS_SECRET_ACCESS_KEY" = user_admin$SecretAccessKey
+  ), {
+    # read
+    aws_bucket_list_objects(bucket)
+
+    # write
+    links_rds_file <- file.path(system.file(), "Meta/links.rds")
+    six_bucket_upload(path = links_rds_file, remote = bucket, force = TRUE)
+  }
+)
+#> [1] "s3://bucketqozlabhg/links.rds"
+```
+
+User UpstartCoding does have access for read and write, as intended.
+
+## Cleanup
+
+Then cleanup the users, groups and buckets:
+
+
+``` r
+# Users
+map(c(name_admin, names_users, name_user_wo), six_user_delete)
+
+# Groups
+map(c("myadmin", "myusers"), six_group_delete)
+
+# Bucket
+six_bucket_delete(bucket, force = TRUE)
+```

--- a/vignettes/s3iam.Rmd.og
+++ b/vignettes/s3iam.Rmd.og
@@ -7,7 +7,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r setup, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
@@ -20,7 +20,7 @@ A common use case is to manage a small group of users and their access to AWS re
 
 ## Installation
 
-```{r setup}
+```{r load-pkgs}
 library(sixtyfour)
 library(purrr)
 ```
@@ -99,19 +99,29 @@ withr::with_envvar(
 
 User `r user_wo_access$UserName` does not have access (read or write), as intended.
 
-Then check access for a user that should have read access:
+Then check access for a user that should have read access and NOT write access:
 
-```{r verify-user, error=TRUE}
+```{r verify-user-read}
+# Read
 withr::with_envvar(
   c("AWS_REGION" = users_non_admin[[1]]$AwsRegion,
     "AWS_ACCESS_KEY_ID" = users_non_admin[[1]]$AccessKeyId,
     "AWS_SECRET_ACCESS_KEY" = users_non_admin[[1]]$SecretAccessKey
   ),
   {
-    # read
     aws_bucket_list_objects(bucket)
+  }
+)
+```
 
-    # write
+```{r verify-user-write, error=TRUE}
+# Write
+withr::with_envvar(
+  c("AWS_REGION" = users_non_admin[[1]]$AwsRegion,
+    "AWS_ACCESS_KEY_ID" = users_non_admin[[1]]$AccessKeyId,
+    "AWS_SECRET_ACCESS_KEY" = users_non_admin[[1]]$SecretAccessKey
+  ),
+  {
     links_rds_file <- file.path(system.file(), "Meta/links.rds")
     six_bucket_upload(path = links_rds_file, remote = bucket, force = TRUE)
   }
@@ -122,23 +132,32 @@ User `r users_non_admin[[1]]$UserName` does have access for read and NOT for wri
 
 And make sure the admin has read and write access
 
-```{r verify-admin}
+```{r verify-admin-read}
+# Read
 withr::with_envvar(
   c("AWS_REGION" = user_admin$AwsRegion,
     "AWS_ACCESS_KEY_ID" = user_admin$AccessKeyId,
     "AWS_SECRET_ACCESS_KEY" = user_admin$SecretAccessKey
   ), {
-    # read
     aws_bucket_list_objects(bucket)
+  }
+)
+```
 
-    # write
+```{r verify-admin-write}
+# Write
+withr::with_envvar(
+  c("AWS_REGION" = user_admin$AwsRegion,
+    "AWS_ACCESS_KEY_ID" = user_admin$AccessKeyId,
+    "AWS_SECRET_ACCESS_KEY" = user_admin$SecretAccessKey
+  ), {
     links_rds_file <- file.path(system.file(), "Meta/links.rds")
     six_bucket_upload(path = links_rds_file, remote = bucket, force = TRUE)
   }
 )
 ```
 
-User `r user_admin$UserName` does have access for read and write, as intended.
+User `r user_admin$UserName` DOES have access for read and write, as intended.
 
 ## Cleanup
 

--- a/vignettes/s3iam.Rmd.og
+++ b/vignettes/s3iam.Rmd.og
@@ -1,0 +1,156 @@
+---
+title: "Managing buckets in a small group of users"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Managing buckets in a small group of users}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+library(sixtyfour)
+aws_configure(redacted = TRUE)
+```
+
+A common use case is to manage a small group of users and their access to AWS resources. This can be done using the `sixtyfour` package, which provides a set of high-level functions to make your life easier.
+
+## Installation
+
+```{r setup}
+library(sixtyfour)
+library(purrr)
+```
+
+## User groups
+
+First, create two user groups - `admin` and `users` - with the `six_admin_setup()` function.
+
+```{r delete-admin-user-groups, echo=FALSE}
+if (aws_group_exists("myadmin")) without_verbose(six_group_delete("myadmin"))
+if (aws_group_exists("myusers")) without_verbose(six_group_delete("myusers"))
+```
+
+```{r setup-admin-user-groups}
+six_admin_setup(users_group = "myusers", admin_group = "myadmin")
+```
+
+## Users
+
+Next, create five users - one in the `admin` group, three in the `users` group, and one not in either group.
+
+The admin user:
+
+```{r create-admin-user, results='hide'}
+name_admin <- random_user()
+user_admin <- six_user_create(name_admin, copy_to_cb = FALSE)
+aws_user_add_to_group(name_admin, "myadmin")
+```
+
+The non-admin users:
+
+```{r create-non-admin-users}
+users_non_admin <- map(1:3, \(x) {
+  six_user_create(random_user(), copy_to_cb = FALSE)
+})
+invisible(map(users_non_admin, \(x) {
+  aws_user_add_to_group(x$UserName, "myusers")
+}))
+names_users <- map_chr(users_non_admin, \(x) x$UserName)
+```
+
+And last, create a user that is not part of either of the above groups.
+
+```{r create-wo-access-user}
+name_user_wo <- random_user()
+user_wo_access <- six_user_create(name_user_wo, copy_to_cb = FALSE)
+```
+
+## Buckets and files
+
+Create a bucket, and put a file in it.
+
+```{r create-bucket}
+bucket <- random_string("bucket")
+demo_rds_file <- file.path(system.file(), "Meta/demo.rds")
+six_bucket_upload(path = demo_rds_file, remote = bucket, force = TRUE)
+```
+
+## Check access
+
+Then check access for the user that should not have access
+
+```{r sleep-so-it-all-works, echo=FALSE, results="hide"}
+Sys.sleep(15)
+```
+
+```{r verify-user-wo, error=TRUE}
+withr::with_envvar(
+  c("AWS_REGION" = user_wo_access$AwsRegion,
+    "AWS_ACCESS_KEY_ID" = user_wo_access$AccessKeyId,
+    "AWS_SECRET_ACCESS_KEY" = user_wo_access$SecretAccessKey
+  ),
+  aws_bucket_list_objects(bucket)
+)
+```
+
+User `r user_wo_access$UserName` does not have access (read or write), as intended.
+
+Then check access for a user that should have read access:
+
+```{r verify-user, error=TRUE}
+withr::with_envvar(
+  c("AWS_REGION" = users_non_admin[[1]]$AwsRegion,
+    "AWS_ACCESS_KEY_ID" = users_non_admin[[1]]$AccessKeyId,
+    "AWS_SECRET_ACCESS_KEY" = users_non_admin[[1]]$SecretAccessKey
+  ),
+  {
+    # read
+    aws_bucket_list_objects(bucket)
+
+    # write
+    links_rds_file <- file.path(system.file(), "Meta/links.rds")
+    six_bucket_upload(path = links_rds_file, remote = bucket, force = TRUE)
+  }
+)
+```
+
+User `r users_non_admin[[1]]$UserName` does have access for read and NOT for write, as intended.
+
+And make sure the admin has read and write access
+
+```{r verify-admin}
+withr::with_envvar(
+  c("AWS_REGION" = user_admin$AwsRegion,
+    "AWS_ACCESS_KEY_ID" = user_admin$AccessKeyId,
+    "AWS_SECRET_ACCESS_KEY" = user_admin$SecretAccessKey
+  ), {
+    # read
+    aws_bucket_list_objects(bucket)
+
+    # write
+    links_rds_file <- file.path(system.file(), "Meta/links.rds")
+    six_bucket_upload(path = links_rds_file, remote = bucket, force = TRUE)
+  }
+)
+```
+
+User `r user_admin$UserName` does have access for read and write, as intended.
+
+## Cleanup
+
+Then cleanup the users, groups and buckets:
+
+```{r cleanup, message=FALSE, results='hide'}
+# Users
+map(c(name_admin, names_users, name_user_wo), six_user_delete)
+
+# Groups
+map(c("myadmin", "myusers"), six_group_delete)
+
+# Bucket
+six_bucket_delete(bucket, force = TRUE)
+```


### PR DESCRIPTION
fix #27 

Some notes:

- This is a tricky one since we don't yet have a simulate user function (#57 ) and we need to hide all secrets, so there's a combination of approaches
- Using our `aws_configure(redacted = TRUE)` in the knitr setup to redact where we've set that up already
- Using `without_verbose` with block in a few places to suppress cli output that has secrets
- Using `results='hide'` in a few places to reduce output of secrets
- Using `invisible()` in a few places to reduce output of secrets
- There's even use of `sed` to replace the account id - this is not ideal and only works on my machine (TM), so not a permanent solution. knitr output hooks should do the trick, or we could build in redacting account ids, but they can show up in a lot of places, so i'm hesitant to take on that work
- There's a `Sys.sleep(15)` before we check access because apparently there's a little lag time between creating a user and its credentials and the aws api knowing about that