### PR TITLE
add detailed information on what redacted does; add what verbose does

### DIFF
--- a/R/configure.R
+++ b/R/configure.R
@@ -4,15 +4,38 @@ env64 <- rlang::env()
 #'
 #' @export
 #' @param redacted (logical) Redact secrets? Default: `FALSE`. If `TRUE`,
-#' secret values are redacted (replaced with `*****`) only in printed
-#' messages to the console, and are not redacted in the output from
-#' running functions.
+#' secret values are redacted (replaced with `redact_str`) in certain
+#' messages and output from functions. See *What is Redacted* below.
 #' @param redact_str (character) String to use to replace redacted values.
 #' Default: `"*****"`
-#' @param verbose (logical) Print verbose output? Default: `TRUE`.
+#' @param verbose (logical) Print verbose output? Default: `TRUE`. Applies
+#' only to `cli::cli_alert_info()`, `cli::cli_alert_warning()`, and
+#' `cli::cli_alert_success()` functions that are used throughout this package.
+#' There's still a few places where `verbose` may not be respected.
+#' @section What is Redacted:
+#' What's redacted is currently hard-coded in the package. There's only
+#' certain functions and certain elements in the output of those functions
+#' that are redacted. The following is what's redacted with
+#' `aws_configure(redacted = TRUE)` or `with_redacted()`:
+#'
+#' - `aws_whoami()`: AWS Account ID via `account_id()`
+#' - `six_user_creds()`: Access Key ID
+#' - groups functions:
+#'   - functions: `aws_groups()`, `aws_group()`, `aws_group_create()`
+#'   - attribute: `Arn` (includes AWS Account ID)
+#' - roles functions:
+#'   - functions: `aws_roles()`, `aws_role()`, `aws_role_create()`
+#'   - attribute: `Arn` (includes AWS Account ID)
+#' - user functions:
+#'   - functions: `aws_users()`, `aws_user()`, `aws_user_create()`,
+#' `aws_user_add_to_group()`, `aws_user_remove_from_group()`
+#'   - attribute: `Arn` (includes AWS Account ID)
+#' - `aws_user_access_key_delete()`: Access Key ID
 aws_configure <- function(
-    redacted = FALSE, redact_str = "*****",
-    verbose = TRUE) {
+  redacted = FALSE,
+  redact_str = "*****",
+  verbose = TRUE
+) {
   env64$redacted <- redacted
   env64$redact_str <- redact_str
   env64$verbose <- verbose
@@ -38,7 +61,7 @@ without_verbose <- function(code) {
   force(code)
 }
 
-#' Without secrets redacted
+#' With secrets redacted
 #' @export
 #' @param code (expression) Code to run with secrets redacted
 with_redacted <- function(code) {

--- a/man/aws_configure.Rd
+++ b/man/aws_configure.Rd
@@ -8,15 +8,46 @@ aws_configure(redacted = FALSE, redact_str = "*****", verbose = TRUE)
 }
 \arguments{
 \item{redacted}{(logical) Redact secrets? Default: \code{FALSE}. If \code{TRUE},
-secret values are redacted (replaced with \verb{*****}) only in printed
-messages to the console, and are not redacted in the output from
-running functions.}
+secret values are redacted (replaced with \code{redact_str}) in certain
+messages and output from functions. See \emph{What is Redacted} below.}
 
 \item{redact_str}{(character) String to use to replace redacted values.
 Default: \code{"*****"}}
 
-\item{verbose}{(logical) Print verbose output? Default: \code{TRUE}.}
+\item{verbose}{(logical) Print verbose output? Default: \code{TRUE}. Applies
+only to \code{cli::cli_alert_info()}, \code{cli::cli_alert_warning()}, and
+\code{cli::cli_alert_success()} functions that are used throughout this package.
+There's still a few places where \code{verbose} may not be respected.}
 }
 \description{
 Configure sixtyfour settings
 }
+\section{What is Redacted}{
+
+What's redacted is currently hard-coded in the package. There's only
+certain functions and certain elements in the output of those functions
+that are redacted. The following is what's redacted with
+\code{aws_configure(redacted = TRUE)} or \code{with_redacted()}:
+\itemize{
+\item \code{aws_whoami()}: AWS Account ID via \code{account_id()}
+\item \code{six_user_creds()}: Access Key ID
+\item groups functions:
+\itemize{
+\item functions: \code{aws_groups()}, \code{aws_group()}, \code{aws_group_create()}
+\item attribute: \code{Arn} (includes AWS Account ID)
+}
+\item roles functions:
+\itemize{
+\item functions: \code{aws_roles()}, \code{aws_role()}, \code{aws_role_create()}
+\item attribute: \code{Arn} (includes AWS Account ID)
+}
+\item user functions:
+\itemize{
+\item functions: \code{aws_users()}, \code{aws_user()}, \code{aws_user_create()},
+\code{aws_user_add_to_group()}, \code{aws_user_remove_from_group()}
+\item attribute: \code{Arn} (includes AWS Account ID)
+}
+\item \code{aws_user_access_key_delete()}: Access Key ID
+}
+}
+

--- a/man/with_redacted.Rd
+++ b/man/with_redacted.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/configure.R
 \name{with_redacted}
 \alias{with_redacted}
-\title{Without secrets redacted}
+\title{With secrets redacted}
 \usage{
 with_redacted(code)
 }
@@ -10,5 +10,5 @@ with_redacted(code)
 \item{code}{(expression) Code to run with secrets redacted}
 }
 \description{
-Without secrets redacted
+With secrets redacted
 }


### PR DESCRIPTION
fix #111 

This documents what redacted and verbose actually do

note: this is a PR against `getting-started-edits` branch as it had some changes that affected this work