### PR TITLE
cran checks badge, cran version badge, wilds badge change

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -3,9 +3,11 @@
 # sixtyfour
 
 <!-- badges: start -->
-[![Project Status: Prototype – Useable, some support, open to feedback, unstable API.](https://getwilds.org/badges/badges/prototype.svg)](https://getwilds.org/badges/#prototype)
+[![Project Status: Stable – Useable, full support, open to feedback, stable API.](https://getwilds.org/badges/badges/stable.svg)](https://getwilds.org/badges/#stable)
 [![R-CMD-check](https://github.com/getwilds/sixtyfour/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/getwilds/sixtyfour/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/gh/getwilds/sixtyfour/branch/main/graph/badge.svg)](https://app.codecov.io/gh/getwilds/sixtyfour)
+[![cran version](https://www.r-pkg.org/badges/version/sixtyfour)](https://cran.r-project.org/package=sixtyfour)
+[![cran checks](https://badges.cranchecks.info/worst/sixtyfour.svg)](https://CRAN.R-project.org/package=sixtyfour)
 <!-- badges: end -->
 
 A science-focused, more humane R interface to AWS.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 # sixtyfour
 
 <!-- badges: start -->
-[![Project Status: Prototype – Useable, some support, open to feedback, unstable API.](https://getwilds.org/badges/badges/prototype.svg)](https://getwilds.org/badges/#prototype)
+[![Project Status: Stable – Useable, full support, open to feedback, stable API.](https://getwilds.org/badges/badges/stable.svg)](https://getwilds.org/badges/#stable)
 [![R-CMD-check](https://github.com/getwilds/sixtyfour/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/getwilds/sixtyfour/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/gh/getwilds/sixtyfour/branch/main/graph/badge.svg)](https://app.codecov.io/gh/getwilds/sixtyfour)
+[![cran version](https://www.r-pkg.org/badges/version/sixtyfour)](https://cran.r-project.org/package=sixtyfour)
+[![cran checks](https://badges.cranchecks.info/worst/sixtyfour.svg)](https://CRAN.R-project.org/package=sixtyfour)
 <!-- badges: end -->
 
 A science-focused, more humane R interface to AWS.


### PR DESCRIPTION
fix #127 

the only thing from our rules table in Notion that isn't already done is perhaps the **Detailed README** rule, for which we have 

> Human review to dos:

> - README needs
    - description of what the software does
    - how to install it
    - examples of usage (OR could be in a separate vignette/article)
    - badges for automated testing outcomes, CI, etc.
    - “detailed information about who the software is intended for, how it’s intended to be used, with fully-worked examples of how to install and use the software.” 👈🏽👈🏽👈🏽  
> - All exported functions/classes/etc. need documentation
> - Standalone website that contains more detailed information about the software

----

I think just that one line is what we maybe haven't done, which would be a good thing for the readme